### PR TITLE
Fix test warnings and fix a failure with trial release of DateTime::Locale

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -19,6 +19,10 @@ match    = cover_db
 perl = 5.006
 Params::Validate = 0.52
 
+[Prereqs / TestRequires]
+Test::MockTime = 0
+Test::More = 0
+
 [ReportVersions::Tiny]
 
 [MetaResources]

--- a/t/05conversion.t
+++ b/t/05conversion.t
@@ -51,7 +51,7 @@ for my $test ([ 1,  1,   1 => 1873,  9,  8 ],
     my $date_g = DateTime->from_object( object => $date );
 
     isa_ok( $date_g, 'DateTime', 'converted date'. $date->datetime );
-    is( $date_g->ymd, sprintf '%04d-%02d-%02d', $yg, $mg, $dg,
+    is( $date_g->ymd, sprintf( '%04d-%02d-%02d', $yg, $mg, $dg ),
             '... correctly' );
     is( $date->utc_rd_as_seconds, $date_g->utc_rd_as_seconds,
         'utc_rd_as_seconds is equal' );
@@ -59,7 +59,7 @@ for my $test ([ 1,  1,   1 => 1873,  9,  8 ],
     my $date_p = DateTime::Calendar::Pataphysical->from_object(
                 object => $date_g );
     isa_ok( $date_p, "DateTime::Calendar::Pataphysical", 'and back' );
-    is( $date_p->ymd, sprintf '%0.3d-%0.2d-%0.2d', $yp, $mp, $dp,
+    is( $date_p->ymd, sprintf( '%0.3d-%0.2d-%0.2d', $yp, $mp, $dp ),
         '... correctly' );
 }
 

--- a/t/07lang.t
+++ b/t/07lang.t
@@ -1,7 +1,8 @@
 use strict;
 BEGIN { $^W = 1 }
 
-use Test::More tests => 13;
+use Test::MockTime qw( set_absolute_time );
+use Test::More tests => 9;
 use DateTime::Calendar::Pataphysical;
 
 #########################
@@ -9,21 +10,17 @@ use DateTime::Calendar::Pataphysical;
 my $d = DateTime::Calendar::Pataphysical->new(
             year => 130, month => 7, day => 1 );
 
-isa_ok( $d->locale, 'DateTime::Locale::fr' );
 is( $d->day_name, 'dimanche', 'French week name' );
 
 $d = DateTime::Calendar::Pataphysical->new(
             year => 130, month => 7, day => 4, locale => 'English' );
 
-isa_ok( $d->locale, 'DateTime::Locale::root' );
 is( $d->day_name, 'Wednesday', 'English week name' );
 
 $d->set( locale => 'French' );
-isa_ok( $d->locale, 'DateTime::Locale::fr' );
 
 my $l = DateTime::Locale->load( 'Dutch' );
 $d->set( locale => $l );
-isa_ok( $d->locale, 'DateTime::Locale::nl' );
 is( $d->day_name, 'woensdag', 'Dutch week name' );
 
 $d = DateTime::Calendar::Pataphysical->new(
@@ -35,19 +32,16 @@ is( $d->day_name, 'Hunyadi', 'English name Hunyadi' );
 
 $d = DateTime::Calendar::Pataphysical->from_epoch( epoch => 0,
                                                    locale => 'English' );
-isa_ok( $d->locale, 'DateTime::Locale::root',
-        'from_epoch() accepts locale' );
+is( $d->day_name, 'Wednesday', 'from_epoch() accepts locale' );
 
+set_absolute_time(0);
 $d = DateTime::Calendar::Pataphysical->now( locale => 'Dutch' );
-isa_ok( $d->locale, 'DateTime::Locale::nl',
-        'now() accepts locale' );
+is( $d->day_name, 'woensdag', 'now() accepts locale' );
 
 $d = DateTime::Calendar::Pataphysical->from_object( object => $d,
                                                     locale => 'English' );
-isa_ok( $d->locale, 'DateTime::Locale::root',
-        'from_object() accepts locale' );
+is( $d->day_name, 'Wednesday', 'from_object() accepts locale' );
 
 $d = DateTime::Calendar::Pataphysical->last_day_of_month(
             year => 130, month => 1, locale => 'Dutch' );
-isa_ok( $d->locale, 'DateTime::Locale::nl',
-        'last_day_of_month() accepts locale' );
+is( $d->day_name, 'hunyadi', 'last_day_of_month() accepts locale' );


### PR DESCRIPTION
I couldn't get `dzil release` to run because of what appears to be Latin-1 data in the module file.
