### PR TITLE
Add META.json to distribution tarball

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -4,6 +4,7 @@ license = Perl_5
 copyright_holder = Eugene van der Pijll
 
 [PkgVersion]
+[MetaJSON]
 
 [@Filter]
 -bundle = @Basic


### PR DESCRIPTION
It's considered good practice to include the META.json and META.yml
files to distributions so that various tools in the CPAN ecosystem can
easily extract and use the dist's metadata.  This commit adds the
META.json file to the distribution tarball and addresses the
`has_meta_json` extra kwalitee issue noted for this dist on
[CPANTS](https://cpants.cpanauthors.org/).

This PR is submitted in the hope that it is useful. If you would like anything changed, please just let me know and I'll update and resubmit the PR as necessary.