### PR TITLE
Add 'provides' information to META.yml output

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -37,6 +37,8 @@ repository.type   = git
 bugtracker.web    = http://rt.cpan.org/NoAuth/Bugs.html?Dist=DateTime-Calendar-Pataphysical
 bugtracker.mailto = bug-datetime-calendar-pataphysical@rt.cpan.org
 
+[MetaProvides::Package]
+
 [MetaTests]
 [PodSyntaxTests]
 [PodCoverageTests]


### PR DESCRIPTION
This change addresses the `meta_yml_has_provides` experimental issue
noted on [CPANTS](https://cpants.cpanauthors.org/) for this dist.

I wasn't 100% sure where to put this extra section in `dist.ini` (just after the `MetaResources` seemed logical), so if you'd like it placed somewhere else, just let me know and I'll update the PR and resubmit.